### PR TITLE
Mac os build fix

### DIFF
--- a/buildEncoderAndServerMacOS.sh
+++ b/buildEncoderAndServerMacOS.sh
@@ -15,11 +15,11 @@ mkdir ffmpeg
 cd ffmpeg
 
 # NOTE: This link will need to be updated whenever ffmpeg creates a new binary release
-wget https://evermeet.cx/ffmpeg/ffmpeg-100675-gf359575c0b.7z
+wget https://evermeet.cx/ffmpeg/ffmpeg-4.3.1.7z
 
-../utils/unar ffmpeg-100675-gf359575c0b.7z
+../utils/unar ffmpeg-4.3.1.7z
 
-rm ffmpeg-100675-gf359575c0b.7z
+rm ffmpeg-4.3.1.7z
 
 cd ..
 

--- a/buildEncoderAndServerMacOS.sh
+++ b/buildEncoderAndServerMacOS.sh
@@ -14,11 +14,12 @@ mkdir ffmpeg
 
 cd ffmpeg
 
-curl -O https://evermeet.cx/ffmpeg/ffmpeg-98066-gbd6336b970.7z
+# NOTE: This link will need to be updated whenever ffmpeg creates a new binary release
+wget https://evermeet.cx/ffmpeg/ffmpeg-100675-gf359575c0b.7z
 
-../utils/unar ffmpeg-98066-gbd6336b970.7z
+../utils/unar ffmpeg-100675-gf359575c0b.7z
 
-rm ffmpeg-98066-gbd6336b970.7z
+rm ffmpeg-100675-gf359575c0b.7z
 
 cd ..
 

--- a/buildEncoderAndServerMacOS.sh
+++ b/buildEncoderAndServerMacOS.sh
@@ -27,11 +27,13 @@ rm -r -f *zip*
 
 rm -r -f *tar*
 
-curl -O https://dl.google.com/go/go1.11.1.darwin-amd64.tar.gz
+wget https://golang.org/dl/go1.15.7.darwin-amd64.tar.gz
 
-tar xvzf go1.11.1.darwin-amd64.tar.gz
+tar xvzf go1.15.7.darwin-amd64.tar.gz 
 
-rm go1.11.1.darwin-amd64.tar.gz
+rm go1.15.7.darwin-amd64.tar.gz  
+
+go/bin/go mod init github.com/streamlinevideo/low-latency-preview
 
 go/bin/go get -d -v .
 

--- a/handlers/dashplayhandle.go
+++ b/handlers/dashplayhandle.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"path"
 
-	"../utils"
+	"github.com/streamlinevideo/low-latency-preview/utils"
 )
 
 type DashPlayHandler struct {

--- a/handlers/filedeletehandler.go
+++ b/handlers/filedeletehandler.go
@@ -6,7 +6,7 @@ import (
 	"path"
 	"time"
 
-	"../utils"
+	"github.com/streamlinevideo/low-latency-preview/utils"
 )
 
 // UploadHandler handles for http delete

--- a/handlers/filedownloadhandler.go
+++ b/handlers/filedownloadhandler.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"../utils"
+	"github.com/streamlinevideo/low-latency-preview/utils"
 )
 
 type FileDownloadHandler struct {

--- a/handlers/fileuploadhandler.go
+++ b/handlers/fileuploadhandler.go
@@ -8,7 +8,7 @@ import (
 	"path"
 	"time"
 
-	"../utils"
+	"github.com/streamlinevideo/low-latency-preview/utils"
 	"github.com/gorilla/mux"
 )
 

--- a/main.go
+++ b/main.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"./handlers"
-	"./utils"
+	"github.com/streamlinevideo/low-latency-preview/handlers"
+	"github.com/streamlinevideo/low-latency-preview/utils"
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
 )


### PR DESCRIPTION
Changes to build and run the repo on macOS. Tested on macOS Catalina 10.15.7.

To test, run the following command to install and build the branch:

`
curl -o macOS-build-fix.zip https://codeload.github.com/streamlinevideo/low-latency-preview/zip/macOS-build-fix && unzip macOS-build-fix.zip && cd low-latency-preview-macOS-build-fix/ && ./buildEncoderAndServerMacOS.sh
`

Then follow the directions on the README.md to launch the server and encoder.